### PR TITLE
View time reports functionality upgrade

### DIFF
--- a/TimeTracking/core/timetracking_api.php
+++ b/TimeTracking/core/timetracking_api.php
@@ -18,6 +18,8 @@ trigger_error( ERROR_GENERIC, ERROR );
 $t_timereport_table = plugin_table('data', 'TimeTracking');
 $t_bug_table = db_get_table( 'mantis_bug_table' );
 $t_user_table = db_get_table( 'mantis_user_table' );
+$t_project_table = db_get_table( 'mantis_project_table' );
+
 if( !is_blank( $c_from ) ) {
 $t_from_where = " AND expenditure_date >= $c_from";
 } else {
@@ -33,7 +35,7 @@ $t_project_where = " AND b.project_id = '$c_project_id'  ";
 } else {
 $t_project_where = '';
 }
-if ( access_has_global_level( plugin_config_get( 'add_threshold' ) ) ){
+if ( !access_has_global_level( plugin_config_get( 'view_others_threshold' ) ) ){
 $t_user_id = auth_get_current_user_id(); 
 $t_user_where = " AND user = '$t_user_id'  ";
 } else {
@@ -41,11 +43,12 @@ $t_user_where = '';
 }
 
 $t_results = array();
-$query = "SELECT u.username, bug_id, expenditure_date, hours, timestamp, info 
-FROM $t_timereport_table tr, $t_bug_table b, $t_user_table u
-WHERE tr.bug_id=b.id and tr.user=u.id
+$query = "SELECT u.username, p.name as project_name, bug_id, expenditure_date, hours, timestamp, info 
+FROM $t_timereport_table tr, $t_bug_table b, $t_user_table u, $t_project_table p
+WHERE tr.bug_id=b.id and tr.user=u.id AND p.id = b.project_id
 $t_project_where $t_from_where $t_to_where $t_user_where
 ORDER BY user, expenditure_date, bug_id";
+
 $result = db_query( $query );
 while( $row = db_fetch_array( $result ) ) {
 $t_results[] = $row;

--- a/TimeTracking/lang/strings_english.txt
+++ b/TimeTracking/lang/strings_english.txt
@@ -3,9 +3,8 @@
    $s_plugin_TimeTracking_subtitle = 'Are you a Developer and have worked on this case? Document your work here.';
    $s_plugin_TimeTracking_user = 'User';
 
-   $s_plugin_TimeTracking_view_threshold = 'View Threshold';
-   $s_plugin_TimeTracking_add_threshold = 'Add Threshold';
-   $s_plugin_TimeTracking_delete_threshold = 'Delete Threshold';
+   $s_plugin_TimeTracking_admin_own_threshold = 'Admin Own Threshold';
+   $s_plugin_TimeTracking_view_others_threshold = 'View Others Threshold';
    $s_plugin_TimeTracking_admin_threshold = 'Admin Threshold';
 
    $s_plugin_TimeTracking_expenditure_date = 'Expenditure Date';

--- a/TimeTracking/lang/strings_french.txt
+++ b/TimeTracking/lang/strings_french.txt
@@ -3,9 +3,8 @@
    $s_plugin_TimeTracking_subtitle = 'Are you a Developer and have worked on this case? Document your work here.';
    $s_plugin_TimeTracking_user = 'User';
 
-   $s_plugin_TimeTracking_view_threshold = 'View Threshold';
-   $s_plugin_TimeTracking_add_threshold = 'Add Threshold';
-   $s_plugin_TimeTracking_delete_threshold = 'Delete Threshold';
+   $s_plugin_TimeTracking_admin_own_threshold = 'Admin Own Threshold';
+   $s_plugin_TimeTracking_view_others_threshold = 'View Others Threshold';
    $s_plugin_TimeTracking_admin_threshold = 'Admin Threshold';
 
    $s_plugin_TimeTracking_expenditure_date = 'Expenditure Date';

--- a/TimeTracking/lang/strings_german.txt
+++ b/TimeTracking/lang/strings_german.txt
@@ -3,9 +3,8 @@
    $s_plugin_TimeTracking_subtitle = 'Sie sind Entwickler und haben abrechenbaren Aufwand zu diesem Problem? Erfassen sie Ihn hier.';
    $s_plugin_TimeTracking_user = 'User';
 
-   $s_plugin_TimeTracking_view_threshold = 'View Threshold';
-   $s_plugin_TimeTracking_add_threshold = 'Add Threshold';
-   $s_plugin_TimeTracking_delete_threshold = 'Delete Threshold';
+   $s_plugin_TimeTracking_admin_own_threshold = 'Admin Own Threshold';
+   $s_plugin_TimeTracking_view_others_threshold = 'View Others Threshold';
    $s_plugin_TimeTracking_admin_threshold = 'Admin Threshold';
 
    $s_plugin_TimeTracking_expenditure_date = 'Aufwandsdatum';

--- a/TimeTracking/lang/strings_spanish.txt
+++ b/TimeTracking/lang/strings_spanish.txt
@@ -3,9 +3,8 @@
    $s_plugin_TimeTracking_subtitle = 'Si has dedicado tiempo a esta incidencia, indicarlo aqui';
    $s_plugin_TimeTracking_user = 'Usuario';
 
-   $s_plugin_TimeTracking_view_threshold = 'View Threshold';
-   $s_plugin_TimeTracking_add_threshold = 'Add Threshold';
-   $s_plugin_TimeTracking_delete_threshold = 'Delete Threshold';
+   $s_plugin_TimeTracking_admin_own_threshold = 'Admin Own Threshold';
+   $s_plugin_TimeTracking_view_others_threshold = 'View Others Threshold';
    $s_plugin_TimeTracking_admin_threshold = 'Admin Threshold';
 
    $s_plugin_TimeTracking_expenditure_date = 'Fecha efectiva';

--- a/TimeTracking/pages/add_record.php
+++ b/TimeTracking/pages/add_record.php
@@ -28,7 +28,7 @@
    $f_month      = gpc_get_int( 'month' );
    $f_day        = gpc_get_int( 'day' );
 
-   access_ensure_bug_level( plugin_config_get( 'add_threshold' ), $f_bug_id );
+   access_ensure_bug_level( plugin_config_get( 'admin_own_threshold' ), $f_bug_id );
 	
    # Current UserID
    $user = auth_get_current_user_id();

--- a/TimeTracking/pages/config_page.php
+++ b/TimeTracking/pages/config_page.php
@@ -33,16 +33,12 @@
          <td class="form-title" colspan="2"><?php echo plugin_lang_get( 'title' ), ': ', plugin_lang_get( 'configuration' ) ?></td>
       </tr>
       <tr <?php echo helper_alternate_class() ?>>
-         <td class="category"><?php echo plugin_lang_get( 'view_threshold' ) ?></td>
-         <td><select name="view_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'view_threshold' ) ) ?></select></td>
+         <td class="category"><?php echo plugin_lang_get( 'admin_own_threshold' ) ?></td>
+         <td><select name="admin_own_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'admin_own_threshold' ) ) ?></select></td>
       </tr>
       <tr <?php echo helper_alternate_class() ?>>
-         <td class="category"><?php echo plugin_lang_get( 'add_threshold' ) ?></td>
-         <td><select name="add_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'add_threshold' ) ) ?></select></td>
-      </tr>
-      <tr <?php echo helper_alternate_class() ?>>
-         <td class="category"><?php echo plugin_lang_get( 'delete_threshold' ) ?></td>
-         <td><select name="delete_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'delete_threshold' ) ) ?></select></td>
+         <td class="category"><?php echo plugin_lang_get( 'view_others_threshold' ) ?></td>
+         <td><select name="view_others_threshold"><?php print_enum_string_option_list( 'access_levels', plugin_config_get( 'view_others_threshold' ) ) ?></select></td>
       </tr>
       <tr <?php echo helper_alternate_class() ?>>
          <td class="category"><?php echo plugin_lang_get( 'admin_threshold' ) ?></td>

--- a/TimeTracking/pages/config_update.php
+++ b/TimeTracking/pages/config_update.php
@@ -31,9 +31,8 @@
       }
    }
 
-   maybe_set_option( 'view_threshold', gpc_get_int( 'view_threshold' ) );
-   maybe_set_option( 'add_threshold', gpc_get_int( 'add_threshold' ) );
-   maybe_set_option( 'delete_threshold', gpc_get_int( 'delete_threshold' ) );
+   maybe_set_option( 'admin_own_threshold', gpc_get_int( 'admin_own_threshold' ) );
+   maybe_set_option( 'view_others_threshold', gpc_get_int( 'view_others_threshold' ) );
    maybe_set_option( 'admin_threshold', gpc_get_int( 'admin_threshold' ) );
 
 

--- a/TimeTracking/pages/delete_record.php
+++ b/TimeTracking/pages/delete_record.php
@@ -24,12 +24,17 @@
    $f_bug_id = gpc_get_int( 'bug_id' );
    $f_delete_id = gpc_get_int( 'delete_id' );
 
-   access_ensure_bug_level( plugin_config_get( 'delete_threshold' ), $f_bug_id );
-
    $table = plugin_table('data', 'TimeTracking');
    $query_pull_timerecords = "SELECT * FROM $table WHERE id = $f_delete_id ORDER BY timestamp DESC";
    $result_pull_timerecords = db_query($query_pull_timerecords);
    $row = db_fetch_array( $result_pull_timerecords );
+
+   $t_user_id = auth_get_current_user_id();
+   if ( $row[user] == $t_user_id) {
+      access_ensure_bug_level( plugin_config_get( 'admin_own_threshold' ), $f_bug_id );
+   } else {	
+      access_ensure_bug_level( plugin_config_get( 'admin_threshold' ), $f_bug_id );
+   }
    $query_delete = "DELETE FROM $table WHERE id = $f_delete_id";        
    db_query($query_delete);
 

--- a/TimeTracking/pages/show_report.php
+++ b/TimeTracking/pages/show_report.php
@@ -105,15 +105,18 @@ $t_plugin_TimeTracking_stats = plugin_TimeTracking_stats_get_project_array( $f_p
 <?php
 $t_sum_in_hours = 0;
 $t_user_summary = array();
+$t_project_summary = array();
 $t_bug_summary = array();
 # Initialize the user summary array
 foreach ( $t_plugin_TimeTracking_stats as $t_item ) {
 $t_user_summary[$t_item['username']] = 0;
+$t_project_summary[$t_item['project_name']] = 0;
 $t_bug_summary[$t_item['bug_id']] = 0;
 }
 foreach ( $t_plugin_TimeTracking_stats as $t_key => $t_item ) {
 $t_sum_in_hours += $t_item['hours'];
 $t_user_summary[$t_item['username']] += $t_item['hours'];
+$t_project_summary[$t_item['project_name']] += $t_item['hours'];
 $t_bug_summary[$t_item['bug_id']] += $t_item['hours'];
 ?>
 <tr <?php echo helper_alternate_class() ?>>
@@ -164,6 +167,29 @@ $t_bug_summary[$t_item['bug_id']] += $t_item['hours'];
 </td>
 <td class="small-caption">
 <?php echo number_format($t_user_value, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_user_value * 60); ?>)
+</td>
+</tr>
+<?php } ?>
+</table>
+
+<BR>
+<table border="1" class="width100" cellspacing="0">
+<tr class="row-category-history">
+<td class="small-caption">
+<?php echo lang_get( 'project_name' ) ?>
+</td>
+<td class="small-caption">
+<?php echo plugin_lang_get( 'hours' ) ?>
+</td>
+</tr>
+
+<?php foreach ( $t_project_summary as $t_project_key => $t_project_value ) { ?>
+<tr <?php echo helper_alternate_class() ?>>
+<td class="small-caption">
+<?php echo lang_get( 'total_time' ); ?>(<?php echo $t_project_key; ?>)
+</td>
+<td class="small-caption">
+<?php echo number_format($t_project_value, 2, '.', ','); ?> (<?php echo db_minutes_to_hhmm( $t_project_value * 60); ?>)
 </td>
 </tr>
 <?php } ?>


### PR DESCRIPTION
Atrol told me in #10338 that this plugin is the NEW time reporting. I had earlier seen it but thought its functionality was not adequate and then continued with the OLD time reporting. I agree that this is better not messing with notes but needed to up it to at least the functionality that was present in the old. Now only a migration script is needed to finally retire the old.

So what has been done:

The show time reports page from the old with minor modifications has been added: (everyone can see their own reports, and currency field is not included since costing usually needs a lot more than just a field. Reporting page shows additional fields for each transaction and is also summarized for each user and bug. Viewers can see the time both as decimal and HH:MM format)

The make time report functionality in the issue page is changed to accept HH:MM format,  like it was before.

I hope you like this and add it  and  we can continue do more things for it.
