### PR TITLE
Fix EVENT_BUGNOTE_ADD parameters

### DIFF
--- a/TimeTracking/TimeTracking.php
+++ b/TimeTracking/TimeTracking.php
@@ -147,7 +147,7 @@ class TimeTrackingPlugin extends MantisPlugin {
 	/**
 	 * Creates a time tracking record from submitted data when adding bugnotes
 	 */
-	function ev_bugnote_added( $p_event, $p_bug_id, $p_bugnote_id ) {
+	function ev_bugnote_added( $p_event, $p_bug_id, $p_bugnote_id, $files) {
 		$t_time_imput = gpc_get_string( 'plugin_timetracking_time_input', '' );
 		if( !is_blank( $t_time_imput ) ) {
 			if( TimeTracking\user_can_edit_bug_id( $p_bug_id ) ) {


### PR DESCRIPTION
Fixed error "Unknown named parameter $files" when call ev_bugnote_added.

https://github.com/mantisbt/mantisbt/commit/491f8ea95857e34add602323e2d7a779f0302dc0